### PR TITLE
Sorting is useless

### DIFF
--- a/tasks/promote_content_view.yml
+++ b/tasks/promote_content_view.yml
@@ -33,7 +33,7 @@
 
 - name: Get last content view version
   set_fact:
-    sat_cv_version_last: "{{ sat_cv.json | json_query(query_cv_version_list) | sort(attribute='version') | last }}"
+    sat_cv_version_last: "{{ sat_cv.json | json_query(query_cv_version_list) | last }}"
 
 - name: Get content view version content
   uri:


### PR DESCRIPTION
The list is already sorted by design.
Perform sorting makes wrong sort of list when version number of CV is greater than 9.0....

Before my fix 

TASK [ogerbron.satellite6_content_views : Get last content view version] *******
task path: /data/jenkins/workspace/promoteCCV/roles/ogerbron.satellite6_content_views/tasks/promote_content_view.yml:34
ok: [localhost] => {
    "****_facts": {
         "sat_cv_version_last": {
             "environment_ids": [
                 73, 
                 74, 
                 75, 
                 45, 
                 46, 
                 48, 
                 49
             ], 
             "id": 156, 
             "version": "9.0"
         }
     }, 
     "changed": false

(*) After my fix (i juste removed the sort..) (*)

TASK [ogerbron.satellite6_content_views : Get last content view version] *******
task path: /data/jenkins/workspace/promoteCCV/roles/ogerbron.satellite6_content_views/tasks/promote_content_view.yml:34
 ok: [localhost] => {
     "****_facts": {
         "sat_cv_version_last": {
             "environment_ids": [
                 1, 
                 44
             ], 
             "id": 211, 
             "version": "13.0"
         }
     }, 
     "changed": false