### PR TITLE
Use published date to do a real sort version instead of version number

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,7 +64,7 @@
 
   - name: Set content view version list
     set_fact:
-      sat_cv_version_list: "{{ sat_cv.json | json_query(query_cv_version_list) | sort(attribute='version') }}"
+      sat_cv_version_list: "{{ sat_cv.json | json_query(query_cv_version_list) | sort(attribute='published') }}"
 
   - name: Set the number of content view version
     set_fact:

--- a/tasks/promote_content_view.yml
+++ b/tasks/promote_content_view.yml
@@ -33,7 +33,7 @@
 
 - name: Get last content view version
   set_fact:
-    sat_cv_version_last: "{{ sat_cv.json | json_query(query_cv_version_list) | sort(attribute='version') | last }}"
+    sat_cv_version_last: "{{ sat_cv.json | json_query(query_cv_version_list) | sort(attribute='published') | last }}"
 
 - name: Get content view version content
   uri:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,7 +19,7 @@ query_organization_id: "results[?name=='{{ sat_org }}'].id | [0]"
 #Content view queries
 query_cv_id: "results[?name=='{{ sat_cv_name }}'].id | [0]"
 query_cv_not_composite: "results[?composite=='false'].id | [0]"
-query_cv_version_list: "versions[*].{id: id, version: version, environment_ids: environment_ids}"
+query_cv_version_list: "versions[*].{id: id, version: version, environment_ids: environment_ids, published: published}"
 query_cv_latest_version_id: "results[?id=={{ item }}].versions[*].environment_ids"
 
 #Composite content view queries


### PR DESCRIPTION
The sort is alphabetically, so if you sort by version you will have version 6 after version 10 (as 6 come after 1) !
So, it's better to add published date to do the sort.