### PR TITLE
change when condition than checks environment ids

### DIFF
--- a/tasks/build_component_ids.yml
+++ b/tasks/build_component_ids.yml
@@ -5,7 +5,7 @@
 - name: Adding latest version id of each content views
   set_fact:
     sat_ccv_component_ids: "{{ sat_ccv_component_ids + [ inner_item.id ] }}"
-  when: 1 in inner_item.environment_ids
+  when: inner_item.environment_ids is defined and (inner_item.environment_ids|length>0)
   with_list: "{{ current_cv_version_list }}"
   loop_control:
     loop_var: inner_item

--- a/tasks/build_component_ids.yml
+++ b/tasks/build_component_ids.yml
@@ -1,3 +1,4 @@
+---
 - name: Getting versions list of current content view
   set_fact:
     current_cv_version_list: "{{ content_view_list.json | json_query(query_ccv_cv_version_list) }}"

--- a/tasks/get_content_view.yml
+++ b/tasks/get_content_view.yml
@@ -1,3 +1,4 @@
+---
 #Get content of content view
 - name: Get content view content
   uri:
@@ -8,3 +9,7 @@
     validate_certs: no
     force_basic_auth: yes
   register: sat_cv
+
+- set_fact:
+    is_composite: "{{ sat_cv.json | json_query('composite') }}"
+    cv_name: "{{ sat_cv.json | json_query('name') }}"

--- a/tasks/promote_to_env.yml
+++ b/tasks/promote_to_env.yml
@@ -1,4 +1,4 @@
-- name: Promote content view {{ sat_cv.json.name }} to {{ item }}
+- name: Promote content view {{ cv_name }} to {{ item }}
   block:
   - name: Setting mandatory vars
     set_fact:
@@ -16,7 +16,7 @@
     when: not sat_env_is_promoted
 
   - block:
-    - name: Promoting the content view {{ sat_cv.json.name }} to {{ item }}
+    - name: Promoting the content view {{ cv_name }} to {{ item }}
       uri:
         url: "{{ sat_url }}/{{ sat_api_path_content_view_versions }}/{{ sat_cv_version_last.id }}/promote"
         method: POST
@@ -39,5 +39,5 @@
 
     rescue:
     - debug:
-        msg: "Could not promote content view {{ sat_cv.json.name }}, error is {{ content_view_promote.json.errors }}"
+        msg: "Could not promote content view {{ cv_name }}, error is {{ content_view_promote.json.errors }}"
     when: not sat_env_is_promoted

--- a/tasks/publish_content_view.yml
+++ b/tasks/publish_content_view.yml
@@ -1,10 +1,9 @@
-- set_fact:
-    is_composite: "{{ sat_cv.json | json_query('composite') }}"
+---
 
 - include: update_composite_view.yml
   when: is_composite
 
-- name: Publish Content View {{ sat_cv.json.name }}
+- name: Publish Content View {{ cv_name }}
   uri:
     url: "{{ sat_url }}/{{ sat_api_path_content_views }}/{{ sat_cv_id }}/publish?organization_id={{ sat_org_id }}"
     method: POST

--- a/tasks/publish_content_view.yml
+++ b/tasks/publish_content_view.yml
@@ -1,5 +1,8 @@
+- set_fact:
+    is_composite: "{{ sat_cv.json | json_query('composite') }}"
+
 - include: update_composite_view.yml
-  when: sat_cv.json.composite
+  when: is_composite
 
 - name: Publish Content View {{ sat_cv.json.name }}
   uri:

--- a/tasks/remove_content_view.yml
+++ b/tasks/remove_content_view.yml
@@ -1,4 +1,4 @@
-- name: Delete old version of content view {{ sat_cv.json.name }} (id is {{ sat_cv_id }}, version is {{ item.id }})
+- name: Delete old version of content view {{ cv_name }} (id is {{ sat_cv_id }}, version is {{ item.id }})
   block:
   - name: Removing content view version {{ item.version }}
     uri:

--- a/tasks/update_composite_view.yml
+++ b/tasks/update_composite_view.yml
@@ -10,7 +10,7 @@
 - include: build_component_ids.yml
   with_items: "{{ sat_cv.json | json_query(query_ccv_component_labels_list) }}"
 
-- name: Update Composite Content View {{ sat_cv.json.name }}
+- name: Update Composite Content View {{ cv_name }}
   uri:
     url: "{{ sat_url }}/{{ sat_api_path_content_views }}/{{ sat_cv_id }}"
     method: PUT

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,7 +17,8 @@ sat_api_path_content_view_versions: "v2/content_view_versions"
 query_organization_id: "results[?name=='{{ sat_org }}'].id | [0]"
 
 #Content view queries
-query_cv_id: "results[?name=='{{ sat_cv_name }}'].id | [0]"
+#query_cv_id: "results[?name=='{{ sat_cv_name }}'].id | [0]"
+query_cv_id: "results[].content_view_components[].content_view | [?name=='{{ sat_cv_name }}'].id |        [0]"
 query_cv_not_composite: "results[?composite=='false'].id | [0]"
 query_cv_version_list: "versions[*].{id: id, version: version, environment_ids: environment_ids, published: published}"
 query_cv_latest_version_id: "results[?id=={{ item }}].versions[*].environment_ids"


### PR DESCRIPTION
With multiple content views and composite content views the ```when: inner_item.environment_ids``` was failing to find 1 in the list of content ids. This check will ensure content views without ids get skippd.