### PR TITLE
Incorrect parameter name environment_id should be environment_ids

### DIFF
--- a/tasks/promote_to_env.yml
+++ b/tasks/promote_to_env.yml
@@ -23,7 +23,7 @@
         body:
           id: "{{ sat_cv_version_last.id }}"
           description: "{{ sat_promote_description }}"
-          environment_id: "{{ sat_env_id }}"
+          environment_ids: "{{ sat_env_id }}"
         body_format: json
         status_code: 202
         user: "{{ sat_user }}"


### PR DESCRIPTION
I noticed that the API request to promote Content Views was failing and returning the error "Could not find environments for promotion". After some investigation I discovered that the API documentation for `POST /katello/api/content_view_versions/:id/promote` says that the parameter is named "environment_ids" not "environment_id". Simply adding the s fixed the problem and allowed my Content View to automatically promote as expected.

Thank you for writing and sharing this role. It is incredibly useful!